### PR TITLE
Migrated to the official OpenSCAD Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:22.04
+FROM openscad/openscad:dev
 
-RUN apt-get update && apt-get install -y --no-install-recommends openscad
+USER root
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -l
 
+# Ensure subfolders exist for the output file
+output_dir=$(dirname "$GITHUB_WORKSPACE/$2")
+mkdir -p "$output_dir"
+
+# Construct the OpenSCAD command
 cmd="openscad -o $GITHUB_WORKSPACE/$2 $GITHUB_WORKSPACE/$1"
 
 if [[ -n "$3" ]]; then
@@ -10,4 +15,5 @@ if [[ -n "$4" ]]; then
   cmd="$cmd -P $4"
 fi
 
+# Execute the command
 $cmd


### PR DESCRIPTION
I used `dev` tagged image because `lastest` tag was published 3 years ago. It may cause some errors but works for me as well.

See: https://hub.docker.com/r/openscad/openscad